### PR TITLE
Implement Update Mutation for Attendance Records

### DIFF
--- a/src/db/attendance.rs
+++ b/src/db/attendance.rs
@@ -9,4 +9,5 @@ pub struct Attendance {
     pub date: NaiveDate,
     pub timein: NaiveTime,
     pub timeout: NaiveTime,
+    pub present: bool,
 }

--- a/src/graphql/mutations.rs
+++ b/src/graphql/mutations.rs
@@ -39,6 +39,7 @@ impl MutationRoot {
         Ok(member)
     }
 
+    
     //Mutation for adding Attendance to the Attendance table
     async fn add_attendance(
         &self,
@@ -59,6 +60,27 @@ impl MutationRoot {
         .bind(timeout)
         .fetch_one(pool.as_ref())
         .await?;
+
+        Ok(attendance)
+    }
+    
+    async fn update_attendance_present(
+        &self,
+        ctx: &Context<'_>,
+        id: i32,
+        date: NaiveDate,
+        present: bool,
+    ) -> Result<Attendance,sqlx::Error> {
+        let pool = ctx.data::<Arc<PgPool>>().expect("Pool not found in context");
+
+        let attendance = sqlx::query_as::<_, Attendance>(
+            "UPDATE Attendance SET present = $1 WHERE id = $2 AND date = $3 RETURNING *"
+        )
+        .bind(present)
+        .bind(id)
+        .bind(date)                                                                                                                                                                         
+        .fetch_one(pool.as_ref())
+        .await?;                            
 
         Ok(attendance)
     }


### PR DESCRIPTION

This pull request introduces a new GraphQL mutation for updating attendance records in our Rust project. The update mutation allows clients to modify existing attendance entries based on date and user id